### PR TITLE
FIX expose public resources since it's necessary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,10 @@
     "installer-name": "starter",
     "branch-alias": {
       "dev-master": "2.x-dev"
-    }
+    },
+    "expose": [
+      "dist"
+    ]
   },
   "suggest": {
     "cwp/cwp": "Much of the functionality in this theme is enabled by this module"


### PR DESCRIPTION
SilverStripe 4.1 introduces the concept of a public subdirectory of the
installation root, which serves as the document root for the webserver. To
be compatible with this themes must now also expose their assets as they
are otherwise no longer within the webroot as they were previously. This
change needs to be made regardless of whether or not one opts into the
public webroot setup (which is currently optional).