### PR TITLE
FIX also expose ico and images from module root

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
       "dev-master": "2.x-dev"
     },
     "expose": [
-      "dist"
+      "dist",
+      "ico",
+      "images"
     ]
   },
   "suggest": {


### PR DESCRIPTION
Although these files are included in the dist folder that is currently
exposed, the template seems to attempt to serve them from the module root
instead - so they also need exposing.

Follows on from #20 