### PR TITLE
FIX Update resource references to actual locations

### DIFF
--- a/templates/Includes/Favicon.ss
+++ b/templates/Includes/Favicon.ss
@@ -1,1 +1,1 @@
-<link rel="shortcut icon" href="{$BaseHref}themes/starter/ico/favicon.ico" />
+<link rel="shortcut icon" href="{$BaseHref}{$ThemeDir}/ico/favicon.ico" />

--- a/templates/Includes/Footer.ss
+++ b/templates/Includes/Footer.ss
@@ -25,7 +25,7 @@
 
     <hr>
     <a href="http://newzealand.govt.nz" class="footer-govt-logo">
-        <img src="themes/starter/images/newzealand-government-footer.png"
+        <img src="$ThemeDir/images/newzealand-government-footer.png"
             width="210"
             alt="<%t CWP.Footer.GovAlt 'newzealand.govt.nz - connecting you to New Zealand central &amp; local government services' %>"
             />


### PR DESCRIPTION
Resources for a theme may now live in the theme folder, in the resources
folder, or the public/resources folder; all of which are resolved at
runtime. To allow for this we can leverage the recently reintroduced
$ThemeDir variable to resolve this for us in our templates, meaning that
we get no more dead links when trying to reference theme images.