### PR TITLE
Hide page showcase background if no features/quicklinks exist

### DIFF
--- a/templates/Includes/PageShowcase.ss
+++ b/templates/Includes/PageShowcase.ss
@@ -1,10 +1,12 @@
 <% if $ClassName == "HomePage" %>
-    <div class="page-showcase">
-        <div class="container">
-            <div class="row">
-                <% include PageShowcaseQuicklinks %>
-                <% include PageShowcaseFeatures %>
+    <% if $FeatureOneTitle || $FeatureTwoTitle || $QuickLinks %>
+        <div class="page-showcase">
+            <div class="container">
+                <div class="row">
+                    <% include PageShowcaseQuicklinks %>
+                    <% include PageShowcaseFeatures %>
+                </div>
             </div>
         </div>
-    </div>
+    <% end_if %>
 <% end_if %>


### PR DESCRIPTION
Is obvious when using Watea theme on top of the starter theme, as it has a grey background and looks out of place.