### PR TITLE
Remove custom date formatting in favour of RFC3339

### DIFF
--- a/templates/Includes/EventItem.ss
+++ b/templates/Includes/EventItem.ss
@@ -5,11 +5,11 @@
     <% end_if %>
     <% if $Date %>
         <time>
-            <span itemprop="startDate" datetime="{$Date.Format('y-MM-dd')}<% if $StartTime %>T{$StartTime.Format('HH:mm:ss')}<% end_if %>">
+            <span itemprop="startDate" datetime="{$Date.Rfc3339}">
                 $Date.Format('dd/MM/y') <% if $StartTime %>$StartTime.Nice<% end_if %>
             </span>
             <% if $EndTime %>
-                <span itemprop="endDate" datetime="{$Date.Format('y-MM-dd')}T{$EndTime.Format('HH:mm:ss')}">- $EndTime.Nice</span>
+                <span itemprop="endDate" datetime="{$Date.Rfc3339}">- $EndTime.Nice</span>
             <% end_if %>
         </time>
     <% end_if %>


### PR DESCRIPTION
Changes:

```diff
- 2018-07-13T00:00:00
+ 2018-07-13T00:00:00+12:00
```

The timezone indication at the end is a valid format for this attribute. This removes some custom formatting and uses a built in mechanism instead.