### PR TITLE
Add content field to news and events holder page templates

### DIFF
--- a/templates/CWP/CWP/PageTypes/Layout/EventHolder.ss
+++ b/templates/CWP/CWP/PageTypes/Layout/EventHolder.ss
@@ -5,6 +5,11 @@
                 $Breadcrumbs
                 <h1>$Title</h1>
             </div>
+            <% if $Content.RichLinks %>
+                $Content.RichLinks
+            <% else %>
+                $Content
+            <% end_if %>
             <% include NewsFilterContext %>
         </div>
 

--- a/templates/CWP/CWP/PageTypes/Layout/NewsHolder.ss
+++ b/templates/CWP/CWP/PageTypes/Layout/NewsHolder.ss
@@ -5,6 +5,11 @@
                 $Breadcrumbs
                 <h1>$Title</h1>
             </div>
+            <% if $Content.RichLinks %>
+                $Content.RichLinks
+            <% else %>
+                $Content
+            <% end_if %>
             <% include NewsFilterContext %>
         </div>
 


### PR DESCRIPTION
Is misleading to content authors because the content field in the CMS indicates they should be able to add content to the page