### PR TITLE
FIX Ensuring columns are correctly rendered for registry

### DIFF
--- a/templates/SilverStripe/Registry/Layout/RegistryPage.ss
+++ b/templates/SilverStripe/Registry/Layout/RegistryPage.ss
@@ -42,7 +42,7 @@
                         <tbody>
                         <% loop $RegistryEntries %>
                             <tr class="<% if $FirstLast %>$FirstLast <% end_if %>$EvenOdd">
-                                <% loop Columns %>
+                                <% loop $Top.Columns($ID) %>
                                     <td><% if $Link %><a href="$Link">$Value</a><% else %>$Value<% end_if %></td>
                                 <% end_loop %>
                             </tr>


### PR DESCRIPTION
When using the starter theme with registry pages the table would not correctly display columns. This PR fixes the issue by ensuring `Columns` is called on the top level controller (like the template provided by the registry module itself exemplifies)