### PR TITLE
FIX Starter theme now correctly resolves the favicon for the frontend

### DIFF
--- a/templates/Includes/Favicon.ss
+++ b/templates/Includes/Favicon.ss
@@ -1,1 +1,1 @@
-<link rel="shortcut icon" href="{$BaseHref}{$ThemeDir}/ico/favicon.ico" />
+<link rel="shortcut icon" href="$resourceURL('themes/starter/ico/favicon.ico')" />


### PR DESCRIPTION
Issue: https://github.com/silverstripe/cwp-watea-theme/issues/31