### PR TITLE
FIX Language selector dropdown is now Bootstrap 4 compliant

### DIFF
--- a/templates/Includes/LanguageSelector.ss
+++ b/templates/Includes/LanguageSelector.ss
@@ -2,15 +2,14 @@
     <div class="btn-group float-right language-selector" id="header-language-toggle">
         <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <i class="fa fa-language" aria-hidden="true"></i>
-            <span class="hidden-xs">
+            <span class="d-none d-sm-inline">
                 $SelectedLanguage
             </span>
-            <span class="caret"></span>
         </button>
         <ul class="dropdown-menu dropdown-menu-right">
             <% loop $Locales %>
-                <li <% if $LinkingMode == 'Current' %> class="active"<% end_if %>>
-                    <a href="$Link" lang="$LocaleRFC1766">
+                <li>
+                    <a href="$Link" lang="$LocaleRFC1766" class="dropdown-item<% if $LinkingMode == 'Current' %> active<% end_if %>">
                         <%-- Note: if you have multiple locales within the same language, you can use $Title instead --%>
                         $LanguageNative
                     </a>


### PR DESCRIPTION
* Add dropdown-item class to dropdown menu list items
* Remove unnecessary caret span (included by default now)
* Update xs visibility classes on selected language label