### PR TITLE
FIX shift to 8 + 3 grid system

### DIFF
--- a/templates/CWP/CWP/PageTypes/Layout/EventHolder.ss
+++ b/templates/CWP/CWP/PageTypes/Layout/EventHolder.ss
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="row">
-        <div class="col-lg-10 offset-lg-1">
+        <div class="col-lg-8">
             <div class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
@@ -13,7 +13,7 @@
             <% include NewsFilterContext %>
         </div>
 
-        <section class="listing <% if $AvailableMonths || not $FilteredUpdates %>col-lg-7<% else %>col-lg-10<% end_if %> offset-lg-1">
+        <section class="listing col-lg-8">
             <% if $FilteredUpdates %>
                 <% include FilteredUpdates ControllerName=$ClassName %>
             <% else %>
@@ -23,7 +23,7 @@
             <% end_if %>
         </section>
 
-        <aside class="col-lg-3 sidebar">
+        <aside class="col-lg-3 offset-lg-1 sidebar">
             <h2 class="sr-only"><%t CWP\\CWP\\PageTypes\\EventHolder.FILTERS "Filters" %></h2>
             <% if $UpdateTagsWithLinks %>
                 <% include UpdateTags %>

--- a/templates/CWP/CWP/PageTypes/Layout/EventPage.ss
+++ b/templates/CWP/CWP/PageTypes/Layout/EventPage.ss
@@ -1,6 +1,6 @@
 <article class="container">
     <div class="row">
-        <section class="col-lg-12">
+        <section class="col-lg-8<% if not $Terms && not $RelatedPages %> offset-lg-2<% end_if %>">
             <header class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
@@ -8,7 +8,7 @@
         </section>
     </div>
     <div class="row">
-        <section class="col-lg-8">
+        <section class="col-lg-8<% if not $Terms && not $RelatedPages %> offset-lg-2<% end_if %>">
             <% include EventItem %>
         </section>
         <aside class="col-lg-3 offset-lg-1 sidebar">

--- a/templates/CWP/CWP/PageTypes/Layout/NewsHolder.ss
+++ b/templates/CWP/CWP/PageTypes/Layout/NewsHolder.ss
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="row">
-        <div class="col-lg-10 offset-lg-1">
+        <div class="col-lg-8">
             <div class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
@@ -13,7 +13,7 @@
             <% include NewsFilterContext %>
         </div>
 
-        <section class="listing <% if $AvailableMonths || not $FilteredUpdates %>col-lg-7 offset-lg-1<% else %>col-lg-10 offset-lg-1<% end_if %>">
+        <section class="listing col-lg-8">
             <% if $FilteredUpdates %>
                 <% include FilteredUpdates ControllerName=$ClassName %>
             <% else %>
@@ -23,7 +23,7 @@
             <% end_if %>
         </section>
 
-        <aside class="col-lg-3 sidebar">
+        <aside class="col-lg-3 offset-lg-1 sidebar">
             <h2 class="sr-only"><%t CWP_NewsEvents.FILTERS "Filters" %></h2>
             <% if $UpdateTagsWithLinks %>
                 <% include UpdateTags %>

--- a/templates/CWP/CWP/PageTypes/Layout/NewsPage.ss
+++ b/templates/CWP/CWP/PageTypes/Layout/NewsPage.ss
@@ -1,6 +1,6 @@
 <article class="container">
     <div class="row">
-        <section class="col-lg-10 offset-lg-1">
+        <section class="col-lg-8<% if not $Terms && not $RelatedPages %> offset-lg-2<% end_if %>">
             <header class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
@@ -8,12 +8,14 @@
         </section>
     </div>
     <div class="row">
-        <section class="col-lg-7 offset-lg-1">
+        <section class="col-lg-8<% if not $Terms && not $RelatedPages %> offset-lg-2<% end_if %>">
             <% include NewsItem %>
         </section>
-        <aside class="col-lg-3 sidebar">
+        <% if $Terms || $RelatedPages %>
+        <aside class="col-lg-3 offset-lg-1 sidebar">
             <% include NewsDetail %>
         </aside>
+        <% end_if %>
     </div>
 </article>
 

--- a/templates/CWP/CWP/PageTypes/Layout/SitemapPage.ss
+++ b/templates/CWP/CWP/PageTypes/Layout/SitemapPage.ss
@@ -1,11 +1,11 @@
 <div class="container layout sitemap-page">
     <div class="row">
-        <div class="col-lg-12">
+        <div class="col-lg-8<% if not $Children %> offset-lg-2<% end_if %>">
             <h1 class="page-header">$Title</h1>
         </div>
     </div>
     <div class="row">
-        <div class="col-lg-9">
+        <div class="col-lg-8<% if not $Children %> offset-lg-2<% end_if %>">
             <div class="clearfix">
                 <% if $Content.RichLinks %>
                     $Content.RichLinks
@@ -33,8 +33,8 @@
             $Form
             $CommentsForm
         </div>
-        <% if Menu(2) %>
-            <aside class="col-lg-3">
+        <% if $Children %>
+            <aside class="col-lg-3 offset-lg-1">
                 <% include SidebarNav %>
             </aside>
         <% end_if %>

--- a/templates/Layout/Page.ss
+++ b/templates/Layout/Page.ss
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="row">
-        <section class="col-md-10 offset-md-1">
+        <section class="col-lg-8<% if not $Children %> offset-lg-2<% end_if %>">
             <div class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
@@ -8,7 +8,7 @@
         </section>
     </div>
     <div class="row">
-        <section class="col-md-8 offset-md-1">
+        <section class="col-lg-8<% if not $Children %> offset-lg-2<% end_if %>">
             <% if $ElementalArea %>
                 <%-- Support for content blocks, if enabled --%>
                 <% if $ElementalArea.RichLinks %>
@@ -28,10 +28,11 @@
             <% include RelatedPages %>
             $CommentsForm
         </section>
-
-        <aside class="col-md-3">
+        <% if $Children %>
+        <aside class="col-lg-3 offset-lg-1">
             <% include SidebarNav %>
         </aside>
+        <% end_if %>
     </div>
 </div>
 <% include PageUtilities %>

--- a/templates/Layout/Page_results.ss
+++ b/templates/Layout/Page_results.ss
@@ -1,7 +1,7 @@
 <div class="content search-results">
      <div class="container">
          <div class="row">
-             <section class="col-lg-10 offset-lg-1">
+             <section class="col-lg-8 offset-lg-2">
                  <div class="pb-2 mt-4 mb-4 pb-3 border-bottom">
                      <h1>$Title.XML</h1>
                  </div>

--- a/templates/Layout/Security.ss
+++ b/templates/Layout/Security.ss
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="row">
-        <section class="col-lg-10 offset-lg-1">
+        <section class="col-lg-8 offset-lg-2">
             <div class="page-header border-bottom pb-3 mt-5 mb-4">
                 $Breadcrumbs
                 <h1>$Title</h1>
@@ -8,7 +8,7 @@
         </section>
     </div>
     <div class="row">
-        <section class="col-lg-10 offset-lg-1">
+        <section class="col-lg-8 offset-lg-2">
             <% if $Content.RichLinks %>
             $Content.RichLinks
             <% else %>

--- a/templates/SilverStripe/Blog/Includes/BlogSideBar.ss
+++ b/templates/SilverStripe/Blog/Includes/BlogSideBar.ss
@@ -1,5 +1,5 @@
 <% if $SideBarView %>
-    <aside id="blog-sidebar" class="col-lg-3">
+    <aside id="blog-sidebar" class="col-lg-3 offset-lg-1">
         $SideBarView
     </aside>
 <% end_if %>

--- a/templates/SilverStripe/Blog/Model/Layout/Blog.ss
+++ b/templates/SilverStripe/Blog/Model/Layout/Blog.ss
@@ -1,13 +1,13 @@
 <div class="container">
     <div class="row">
-        <div class="col-lg-10 offset-lg-1">
+        <div class="col-lg-8 offset-lg-2">
             <div class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
             </div>
         </div>
 
-        <section class="<% if $SideBarView %>col-lg-7<% else %>col-lg-10<% end_if %> offset-lg-1">
+        <section class="col-lg-8<% if not $SideBarView %> offset-lg-2<% end_if %>">
             <div class="blog-main" role="main">
                 <div class="clearfix blog-holder__content">
                     <% if $Content.RichLinks %>

--- a/templates/SilverStripe/Blog/Model/Layout/BlogPost.ss
+++ b/templates/SilverStripe/Blog/Model/Layout/BlogPost.ss
@@ -1,13 +1,13 @@
 <div class="blog-entry container">
     <div class="row">
-        <div class="col-lg-10 offset-lg-1">
+        <div class="col-lg-8 offset-lg-2">
             <div class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
             </div>
         </div>
 
-        <section class="<% if $SideBarView %>col-lg-7<% else %>col-lg-10<% end_if %> offset-lg-1">
+        <section class="col-lg-8<% if not $SideBarView %> offset-lg-2<% end_if %>">
             <article class="blog-post-article">
                 <% if $FeaturedImage %>
                     <p class="post-image">$FeaturedImage.ScaleWidth(795)</p>

--- a/templates/SilverStripe/Blog/Model/Layout/Blog_profile.ss
+++ b/templates/SilverStripe/Blog/Model/Layout/Blog_profile.ss
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="row">
-        <div class="col-lg-10 offset-lg-1">
+        <div class="col-lg-8 offset-lg-2">
             <div class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
@@ -10,7 +10,7 @@
     </div>
 
     <div class="row">
-        <section class="<% if $SideBarView %>col-lg-7<% else %>col-lg-10<% end_if %> offset-lg-1 resultsList">
+        <section class="col-lg-8<% if not $SideBarView %> offset-lg-2<% end_if %> resultsList">
             <% include BlogPostPaginatedList %>
             $Form
             <% include RelatedPages %>

--- a/templates/SilverStripe/IFrame/Layout/IFramePage.ss
+++ b/templates/SilverStripe/IFrame/Layout/IFramePage.ss
@@ -1,6 +1,6 @@
 <article class="container">
     <div class="row">
-        <section class="col-lg-12">
+        <section class="col-lg-8 offset-lg-2">
             <header class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
@@ -8,7 +8,7 @@
         </section>
     </div>
     <div class="row">
-        <section class="col-lg-12">
+        <section class="col-lg-8 offset-lg-2">
             $Content
             <% if $IFrameURL %>
                 <span id="Iframepage-loading" style="display: none;">

--- a/templates/SilverStripe/Registry/Layout/RegistryPage.ss
+++ b/templates/SilverStripe/Registry/Layout/RegistryPage.ss
@@ -1,7 +1,7 @@
 <div class="container">
 
     <div class="row">
-        <section class="col-lg-12">
+        <section class="col-lg-8<% if not $RegistryFilterForm %> offset-lg-2<% end_if %>">
             <header class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
@@ -10,7 +10,7 @@
     </div>
 
     <div class="row">
-        <div class="col-lg-8">
+        <div class="col-lg-8<% if not $RegistryFilterForm %> offset-lg-2<% end_if %>">
 
             $Content
 


### PR DESCRIPTION
As per design update - there was already a grid system in place, however
it was for Bootstrap 3, and the Bootstrap 4 grid has changed. Most notably
a new break size was added at the smaller end of the scale, pushing all
others "up one", so `md` became `lg`. This commit adds more consistency
throughout all templates, and conforms to newer design tweaks for Watea
(which uses Starter as a base via SS4 theme cascades).

Closes #95 