### PR TITLE
FIX Blog breadcrumbs offset is only shown when SideBarView is not enabled

### DIFF
--- a/templates/SilverStripe/Blog/Model/Layout/Blog.ss
+++ b/templates/SilverStripe/Blog/Model/Layout/Blog.ss
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="row">
-        <div class="col-lg-8 offset-lg-2">
+        <div class="col-lg-8<% if not $SideBarView %> offset-lg-2<% end_if %>">
             <div class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5170590/56929072-c9ce8a00-6b2c-11e9-8a20-d876d95a4fbb.png)

After:
![image](https://user-images.githubusercontent.com/5170590/56929082-cfc46b00-6b2c-11e9-8bc0-e74d4d3d6c99.png)
