### PR TITLE
FIX Blog template now offsets correctly when a sidebar exists but has no content

### DIFF
--- a/templates/SilverStripe/Blog/Includes/BlogSideBar.ss
+++ b/templates/SilverStripe/Blog/Includes/BlogSideBar.ss
@@ -1,4 +1,4 @@
-<% if $SideBarView %>
+<% if $SideBarView && $SideBarView.Widgets %>
     <aside id="blog-sidebar" class="col-lg-3 offset-lg-1">
         $SideBarView
     </aside>

--- a/templates/SilverStripe/Blog/Model/Layout/Blog.ss
+++ b/templates/SilverStripe/Blog/Model/Layout/Blog.ss
@@ -1,13 +1,13 @@
 <div class="container">
     <div class="row">
-        <div class="col-lg-8<% if not $SideBarView %> offset-lg-2<% end_if %>">
+        <div class="col-lg-8<% if not $SideBarView || not $SideBarView.Widgets %> offset-lg-2<% end_if %>">
             <div class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
             </div>
         </div>
 
-        <section class="col-lg-8<% if not $SideBarView %> offset-lg-2<% end_if %>">
+        <section class="col-lg-8<% if not $SideBarView || not $SideBarView.Widgets %> offset-lg-2<% end_if %>">
             <div class="blog-main" role="main">
                 <div class="clearfix blog-holder__content">
                     <% if $Content.RichLinks %>

--- a/templates/SilverStripe/Blog/Model/Layout/Blog.ss
+++ b/templates/SilverStripe/Blog/Model/Layout/Blog.ss
@@ -10,10 +10,20 @@
         <section class="col-lg-8<% if not $SideBarView || not $SideBarView.Widgets %> offset-lg-2<% end_if %>">
             <div class="blog-main" role="main">
                 <div class="clearfix blog-holder__content">
-                    <% if $Content.RichLinks %>
-                        $Content.RichLinks
+                    <% if $ElementalArea %>
+                        <%-- Support for content blocks, if enabled --%>
+                        <% if $ElementalArea.RichLinks %>
+                            $ElementalArea.RichLinks %>
+                        <% else %>
+                            $ElementalArea
+                        <% end_if %>
                     <% else %>
-                        $Content
+                        <%-- CMS page content --%>
+                        <% if $Content.RichLinks %>
+                            $Content.RichLinks
+                        <% else %>
+                            $Content
+                        <% end_if %>
                     <% end_if %>
                 </div>
 

--- a/templates/SilverStripe/Blog/Model/Layout/BlogPost.ss
+++ b/templates/SilverStripe/Blog/Model/Layout/BlogPost.ss
@@ -1,13 +1,13 @@
 <div class="blog-entry container">
     <div class="row">
-        <div class="col-lg-8 offset-lg-2">
+        <div class="col-lg-8<% if not $SideBarView || not $SideBarView.Widgets %> offset-lg-2<% end_if %>">
             <div class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
             </div>
         </div>
 
-        <section class="col-lg-8<% if not $SideBarView %> offset-lg-2<% end_if %>">
+        <section class="col-lg-8<% if not $SideBarView || not $SideBarView.Widgets %> offset-lg-2<% end_if %>">
             <article class="blog-post-article">
                 <% if $FeaturedImage %>
                     <p class="post-image">$FeaturedImage.ScaleWidth(795)</p>

--- a/templates/SilverStripe/Blog/Model/Layout/BlogPost.ss
+++ b/templates/SilverStripe/Blog/Model/Layout/BlogPost.ss
@@ -13,7 +13,23 @@
                     <p class="post-image">$FeaturedImage.ScaleWidth(795)</p>
                 <% end_if %>
 
-                <div class="content">$Content</div>
+                <div class="content">
+                    <% if $ElementalArea %>
+                        <%-- Support for content blocks, if enabled --%>
+                        <% if $ElementalArea.RichLinks %>
+                            $ElementalArea.RichLinks %>
+                        <% else %>
+                            $ElementalArea
+                        <% end_if %>
+                    <% else %>
+                        <%-- CMS page content --%>
+                        <% if $Content.RichLinks %>
+                            $Content.RichLinks
+                        <% else %>
+                            $Content
+                        <% end_if %>
+                    <% end_if %>
+                </div>
 
                 <% include SilverStripe\\Blog\\EntryMeta %>
 

--- a/templates/SilverStripe/Blog/Model/Layout/Blog_profile.ss
+++ b/templates/SilverStripe/Blog/Model/Layout/Blog_profile.ss
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="row">
-        <div class="col-lg-8 offset-lg-2">
+        <div class="col-lg-8<% if not $SideBarView || not $SideBarView.Widgets %> offset-lg-2<% end_if %>">
             <div class="page-header">
                 $Breadcrumbs
                 <h1>$Title</h1>
@@ -10,7 +10,7 @@
     </div>
 
     <div class="row">
-        <section class="col-lg-8<% if not $SideBarView %> offset-lg-2<% end_if %> resultsList">
+        <section class="col-lg-8<% if not $SideBarView || not $SideBarView.Widgets %> offset-lg-2<% end_if %> resultsList">
             <% include BlogPostPaginatedList %>
             $Form
             <% include RelatedPages %>

--- a/templates/SilverStripe/Blog/Model/Layout/Blog_profile.ss
+++ b/templates/SilverStripe/Blog/Model/Layout/Blog_profile.ss
@@ -3,7 +3,7 @@
         <div class="col-lg-8<% if not $SideBarView || not $SideBarView.Widgets %> offset-lg-2<% end_if %>">
             <div class="page-header">
                 $Breadcrumbs
-                <h1>$Title</h1>
+                <h1 class="h2">$Title</h1>
             </div>
             <% include SilverStripe\\Blog\\MemberDetails %>
         </div>


### PR DESCRIPTION
Fixes https://github.com/silverstripe/cwp-starter-theme/issues/108

### Templates updated

* Blog
* Blog post
* Blog profile

### Blog profile name

Also, blog profile author name title now looks smaller when compared to the main page title:
![image](https://user-images.githubusercontent.com/5170590/56937461-ebda0380-6b50-11e9-8c51-d3c125434016.png)

Instead of:
![image](https://user-images.githubusercontent.com/5170590/56937466-f3011180-6b50-11e9-8a09-8c573c35471d.png)

### Content blocks support

These templates now support content blocks for content, instead of assuming it will be in `$Content`.