### PR TITLE
FIX Make breadcrumbs aria labels more generic so it can be used in search context as well

### DIFF
--- a/templates/BreadcrumbsTemplate.ss
+++ b/templates/BreadcrumbsTemplate.ss
@@ -1,5 +1,5 @@
 <% if $Pages %>
-    <nav role="navigation" aria-label="<%t CWP_Search.BREADCRUMB "Breadcrumb" %>">
+    <nav role="navigation" aria-label="<%t CWP_Search.BREADCRUMBS "Breadcrumbs" %>">
         <ol class="breadcrumb">
             <li class="breadcrumb-item">
                 <a href="$BaseHref">

--- a/templates/BreadcrumbsTemplate.ss
+++ b/templates/BreadcrumbsTemplate.ss
@@ -1,7 +1,6 @@
 <% if $Pages %>
-    <nav role="navigation">
-        <p class="sr-only" id="breadcrumbs-label"><%t SiteTree.BREADCRUMBSLABEL "You are here" %></p>
-        <ol class="breadcrumb" aria-labelledby="breadcrumbs-label">
+    <nav role="navigation" aria-label="<%t CWP_Search.BREADCRUMB "Breadcrumb" %>">
+        <ol class="breadcrumb">
             <li class="breadcrumb-item">
                 <a href="$BaseHref">
                     <%t SiteTree.DEFAULTHOMETITLE "Home" %>


### PR DESCRIPTION
Fixes https://github.com/silverstripe/cwp-watea-theme/issues/50