### PR TITLE
FIX Sanitise data class in 'view imported data history' link so it resolves correctly

### DIFF
--- a/templates/SilverStripe/Registry/Layout/RegistryPage.ss
+++ b/templates/SilverStripe/Registry/Layout/RegistryPage.ss
@@ -50,7 +50,7 @@
                         </tbody>
                     </table>
 
-                    <a class="historyFeedLink" href="registry-feed/latest/{$DataClass}">
+                    <a class="historyFeedLink" href="registry-feed/latest/{$getClassNameForUrl($DataClass)}">
                         <%t RegistryPage.ViewHistory "View imported data history" %>
                     </a>
                     <div class="resultActions">


### PR DESCRIPTION
Resolves https://github.com/silverstripe/silverstripe-registry/issues/52

Will need to be merge up as well