### PR TITLE
FIX Pagination text colour is now accessible on hovering the current page button

### DIFF
--- a/templates/Includes/CommentPagination.ss
+++ b/templates/Includes/CommentPagination.ss
@@ -12,7 +12,7 @@
                     <% loop $Pages %>
                         <% if $CurrentBool %>
                             <li class="page-item active">
-                                <a class="page-link"><strong>$PageNum</strong></a>
+                                <a class="page-link" href="#"><strong>$PageNum</strong></a>
                             </li>
                         <% else %>
                             <li>

--- a/templates/Includes/CommentPagination.ss
+++ b/templates/Includes/CommentPagination.ss
@@ -12,7 +12,7 @@
                     <% loop $Pages %>
                         <% if $CurrentBool %>
                             <li class="page-item active">
-                                <a class="page-link" href="#"><strong>$PageNum</strong></a>
+                                <span class="page-link"><strong>$PageNum</strong></span>
                             </li>
                         <% else %>
                             <li>

--- a/templates/Includes/Pagination.ss
+++ b/templates/Includes/Pagination.ss
@@ -12,9 +12,9 @@
                 <% loop $PaginationSummary(4) %>
                     <% if $CurrentBool %>
                         <li class="page-item active">
-                            <a class="page-link" href="#">
+                            <span class="page-link">
                                 $PageNum <span class="sr-only"><%t CWP_Pagination.CURRENT_LABEL "(current)" %></span>
-                            </a>
+                            </span>
                         </li>
                     <% else %>
                         <% if $PageNum %>

--- a/templates/Includes/Pagination.ss
+++ b/templates/Includes/Pagination.ss
@@ -11,9 +11,9 @@
                 <% end_if %>
                 <% loop $PaginationSummary(4) %>
                     <% if $CurrentBool %>
-                        <li class="active page-item">
-                            <a class="page-link">
-                                <span>$PageNum <span class="sr-only"><%t CWP_Pagination.CURRENT_LABEL "(current)" %></span></span>
+                        <li class="page-item active">
+                            <a class="page-link" href="#">
+                                $PageNum <span class="sr-only"><%t CWP_Pagination.CURRENT_LABEL "(current)" %></span>
                             </a>
                         </li>
                     <% else %>


### PR DESCRIPTION
Bootstrap tells it to inherit its text colour and remove the text underline if the anchor doesn't have a href attribute.

Fixes https://github.com/silverstripe/cwp-starter-theme/issues/121