### PR TITLE
FIX Add CMS configurable title for iframe to tell screenreaders it contains frame content

### DIFF
--- a/templates/SilverStripe/IFrame/Layout/IFramePage.ss
+++ b/templates/SilverStripe/IFrame/Layout/IFramePage.ss
@@ -17,7 +17,7 @@
                 <div class="sr-only" style="position: absolute; overflow: hidden; clip: rect(0 0 0 0); height: 1px; width: 1px; margin: -1px; padding: 0; border: 0;">
                     <%t IframePage.ExternalNote "Please note the following section of content is possibly being delivered from an external source (IFRAME in HTML terms), and may present unusual experiences for screen readers." %>
                 </div>
-                <iframe id="Iframepage-iframe" style="$Style" src="$IFrameURL" class="$Class Iframepage-iframe">$AlternateContent</iframe>
+                <iframe id="Iframepage-iframe" style="$Style" src="$IFrameURL" class="$Class Iframepage-iframe" title="$IFrameTitle">$AlternateContent</iframe>
             <% end_if %>
             $BottomContent
         </section>


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-iframe/issues/43

Requires https://github.com/silverstripe/silverstripe-iframe/pull/44