### PR TITLE
FIX Add aria-current attribute to selected page nav links

### DIFF
--- a/templates/Includes/MainNav.ss
+++ b/templates/Includes/MainNav.ss
@@ -10,7 +10,7 @@
                 <ul class="nav navbar-nav" role="menubar">
                     <% loop Menu(1) %>
                         <li role="menuitem" class="nav-item $FirstLast $LinkingMode<% if $LinkingMode = current %> active<% end_if %><% if $Children %> dropdown <% end_if %>">
-                            <a href="$Link" <% if $LinkingMode = current %>aria-label="current page"<% end_if %> class="nav-link $LinkingMode">$MenuTitle.XML</a>
+                            <a href="$Link" <% if $LinkingMode = current %>aria-current="page"<% end_if %> class="nav-link $LinkingMode">$MenuTitle.XML</a>
 
                             <% if $Children %>
                                 <button class="btn btn-link float-right navbar-touch-caret" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">


### PR DESCRIPTION
**High priority:** The currently selected page navigation links do not have their visible text as part of their accessible name.
![image](https://user-images.githubusercontent.com/24258161/60304789-89558600-998e-11e9-838e-ba83517e7e4f.png)
**Impact:** Speech input users can interact with a webpage by speaking the visible text labels of menus, links, and buttons that appear on the screen. It is confusing to speech input users when they say a visible text label they see, but the speech command does not work because the component's accessible (programmatic) name does not match the visible label. It is a best practice to have the accessible name to include and begin with the visible text.
**Solution:** Remove the aria-label so that the visible text serves as the accessible name. In order to indicate to non-sighted users which link is the current page, add an aria-current attribute instead to the menu link item.