### PR TITLE
FIX Add aria-labels and remove redundant span attributes

### DIFF
--- a/templates/Includes/PageUtilities.ss
+++ b/templates/Includes/PageUtilities.ss
@@ -21,26 +21,26 @@
                     <% if $ClassName == HomePage %>
                         <% if $AtomLink %>
                             <li class="list-inline-item">
-                                <a href="$AtomLink" class="fa fa-rss">
-                                    <span class="sr-only"><%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %></span>
+                                <a href="$AtomLink" aria-label="<%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %>">
+                                    <i class="fa fa-rss" aria-hidden="true"></i>
                                 </a>
                             </li>
                         <% else_if $RSSLink %>
                             <li class="list-inline-item">
-                                <a href="$RSSLink" class="fa fa-rss">
-                                    <span class="sr-only"><%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %></span>
+                                <a href="$RSSLink" aria-label="<%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %>">
+                                    <i class="fa fa-rss" aria-hidden="true"></i>
                                 </a>
                             </li>
                         <% else_if $DefaultAtomLink %>
                             <li class="list-inline-item">
-                                <a href="$DefaultAtomLink" class="fa fa-rss">
-                                    <span class="sr-only"><%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %></span>
+                                <a href="$DefaultAtomLink" aria-label="<%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %>">
+                                    <i class="fa fa-rss" aria-hidden="true"></i>
                                 </a>
                             </li>
                         <% else_if $DefaultRSSLink %>
                             <li class="list-inline-item">
-                                <a href="$DefaultRSSLink" class="fa fa-rss">
-                                    <span class="sr-only"><%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %></span>
+                                <a href="$DefaultRSSLink" aria-label="<%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %>">
+                                    <i class="fa fa-rss" aria-hidden="true"></i>
                                 </a>
                             </li>
                         <% end_if %>


### PR DESCRIPTION
**Medium priority:** The "Print", "Subscribe", "Facebook", "Twitter" and external link icon fonts are included as a unicode value in the accessible name.
![image](https://user-images.githubusercontent.com/24258161/60305243-14834b80-9990-11e9-9975-5d6feef4c808.png)
**Impact:** If the icon is not hidden from assistive technology users, the meaningless unicode value will be announced, which may confuse users.
**Solution:** Add an aria-label to the links to provide the accessible name and remove the redundant <span> and title elements.

**NOTE:** This PR excludes the external link icon font, we will still need to address this issue.