### PR TITLE
FIX Provide focus on error messages

### DIFF
--- a/templates/Includes/FormFieldMessage.ss
+++ b/templates/Includes/FormFieldMessage.ss
@@ -1,5 +1,5 @@
 <% if $Message %>
-<div id="message-$ID" class="invalid-feedback">
+<div id="message-$ID" class="invalid-feedback" role="alert" aria-atomic="true">
     {$Message}
 </div>
 <% end_if %>


### PR DESCRIPTION
**High priority:**
The error messages for incorrect date entry is visually provided but focus is not directed to the notifications to alert non-sighted users.
![image](https://user-images.githubusercontent.com/24258161/60306601-e2c0b380-9994-11e9-9f06-aa5f1f4786c9.png)
**Impact:** Non-sighted users will not know if their submission was successful or why their entry failed to submit if focus is not sent directly to the error message. They will be forced to manually search for the error message, which may be frustrating and time-consuming.
**Solution:** 
Use an aria alert region on the div container. The error container must be present in the DOM on page load for the error message to be spoken by most screen readers. aria- atomic=true is necessary to make Voiceover on iOS read the error messages after more than one invalid submission.

For more information on this technique, please refer to:
https://www.w3.org/WAI/WCAG21/working-examples/aria- alert-identify-errors/
https://www.w3.org/TR/WCAG20-TECHS/ARIA19.html