### PR TITLE
FIX Ensure that the accessible name starts with the visible label text

### DIFF
--- a/templates/Includes/AvailableMonths.ss
+++ b/templates/Includes/AvailableMonths.ss
@@ -6,7 +6,7 @@
         <ul class="nav nav-pills">
             <% loop $Months %>
                 <li class="nav-item">
-                    <a class="nav-link badge <% if $Active %> badge-primary<% end_if %>" title="$MonthName" aria-label="Archive $Up.YearName $MonthName" href="$MonthLink.XML" <% if $Active %> aria-selected="true"<% end_if %>>$MonthName</a>
+                    <a class="nav-link badge <% if $Active %> badge-primary<% end_if %>" aria-label="$MonthName $Up.YearName Archive" href="$MonthLink.XML" <% if $Active %> aria-selected="true"<% end_if %>>$MonthName</a>
                 </li>
             <% end_loop %>
         </ul>
@@ -15,9 +15,9 @@
     <% if $FilteredUpdates %>
         <% if $FilterDescription %>
             <% if $ControllerName == "EventHolder" %>
-                 <p><a class="small" title="<%t CWP.EventHolder.ShowAllEvents "Show all events" %>" href="$Link"><%t CWP.EventHolder.ShowAllEvents "Show all upcoming events" %></a></p>
+                 <p><a class="small" href="$Link"><%t CWP.EventHolder.ShowAllEvents "Show all upcoming events" %></a></p>
             <% else_if $ControllerName == "NewsHolder" %>
-                 <p><a class="small" title="<%t CWP.NewsHolder.ShowAllNews "Show all news" %>" href="$Link"><%t CWP.NewsHolder.ShowAllNews "Show all news" %></a></p>
+                 <p><a class="small" href="$Link"><%t CWP.NewsHolder.ShowAllNews "Show all news" %></a></p>
             <% end_if %>
         <% end_if %>
     <% end_if %>


### PR DESCRIPTION
**Low priority:** The #nav-link.badge.badge-primary links' accessible names derived from the aria-label attributes do not start with the visible label text.
![image](https://user-images.githubusercontent.com/24258161/60312801-d4809080-99b0-11e9-9c08-edc748f0888b.png)
**Impact:** Speech input users can interact with a webpage by speaking the visible text labels of menus, links, and buttons that appear on the screen. It is confusing to speech input users when they say a visible text label they see, but the speech command does not work because the component's accessible (programmatic) name does not match the visible label. It is a best practice to have the accessible name to include and begin with the visible text.
**Solution:** Ensure that the accessible name matches and/or starts with the visible label text. Remove the redundant title attributes to avoid duplication of the accessible name.

Also removed: redundant title attributes.