### PR TITLE
FIX Remove redundant FilteredUpdates title attribute

### DIFF
--- a/templates/Includes/FilteredUpdates.ss
+++ b/templates/Includes/FilteredUpdates.ss
@@ -8,7 +8,7 @@
         <% end_if %>
 
         <header>
-            <h1 class="h4 listing__title"><a title="$Title" href="$Link">$Title</a></h1>
+            <h1 class="h4 listing__title"><a href="$Link">$Title</a></h1>
         </header>
 
         <% if $Up.ControllerName == 'CWP\\CWP\\PageTypes\\EventHolder' %>


### PR DESCRIPTION
Found a redundant title while making my way through other issues which causes an unnecessary duplication of the accessible name of the link.