### PR TITLE
NEW Add tabindex="-1" to comment submission message for a11y support

### DIFF
--- a/templates/CommentsInterface.ss
+++ b/templates/CommentsInterface.ss
@@ -7,7 +7,7 @@
         <% if $AddCommentForm %>
             <% if $canPostComment %>
                 <% if $ModeratedSubmitted %>
-                    <p id="moderated" class="message good"><%t CommentsInterface_ss.AWAITINGMODERATION 'Your comment has been submitted and is now awaiting moderation.' %></p>
+                    <p id="moderated" class="message good" tabindex="-1"><%t CommentsInterface_ss.AWAITINGMODERATION 'Your comment has been submitted and is now awaiting moderation.' %></p>
                 <% end_if %>
                 $AddCommentForm
             <% else %>


### PR DESCRIPTION
Based on accessibility feedback:

> On submission of the "Post" button, focus should be sent to the submission message in order to confirm the user action.
>
>The easiest way to achieve this is to give the <p> element a tabindex of -1 and call its focus() method.

We opted not to include the focus() call, as the tabindex (likely along with the anchor in the URL) was sufficient for VoiceOver to announce the message first.

(This replicates a [template change in the comments module](https://github.com/silverstripe/silverstripe-comments/pull/289))