### PR TITLE
FIX Remove redundant tags title

### DIFF
--- a/templates/Includes/UpdateTags.ss
+++ b/templates/Includes/UpdateTags.ss
@@ -5,8 +5,7 @@
             <% loop $UpdateTagsWithLinks %>
                 <a href="$Link"
                     <% if $Top.CurrentTag.ID == $ID %> aria-selected="true"<% end_if %>
-                    class="badge <% if $Top.CurrentTag.ID == $ID %> badge-success<% else %> badge-primary<% end_if %>"
-                    title='<%t CWP.Events_News.ViewItemsTagged "View items tagged {Name}" Name=$Name %>'>$Name</a>
+                    class="badge <% if $Top.CurrentTag.ID == $ID %> badge-success<% else %> badge-primary<% end_if %>" Name=$Name %>'>$Name</a>
             <% end_loop %>
         </p>
         <% if $CurrentTag %>


### PR DESCRIPTION
**Low priority:** The title attributes for the "CWP 2.0 Highlights and Upgrade Tips", "CWP 2.0 and Upgrading", "Introducing CWP 2.0", "CWP 2.0", "Releases", "SilverStripe" and "Upgrading" links double up on the accessible name of the links.

![image](https://user-images.githubusercontent.com/24258161/60410391-401a6600-9c1c-11e9-82f8-4bc1c6382525.png)

