### PR TITLE
FIX Remove redundant titles from News and Events

### DIFF
--- a/templates/Includes/EventItem.ss
+++ b/templates/Includes/EventItem.ss
@@ -22,6 +22,6 @@
     $Content
 <% end_if %>
 
-<p><a href="$Parent.Link" title="$Parent.Title" class="hidden-print"><i class="fa fa-angle-left mr-1" aria-hidden="true"></i> <%t CWP.Event.BACK "Back to the event listing" %></a></p>
+<p><a href="$Parent.Link" class="hidden-print"><i class="fa fa-angle-left mr-1" aria-hidden="true"></i><%t CWP.Event.BACK "Back to the event listing" %></a></p>
 
 $Form

--- a/templates/Includes/NewsItem.ss
+++ b/templates/Includes/NewsItem.ss
@@ -18,6 +18,6 @@ $Content.RichLinks
 <% else %>
 $Content
 <% end_if %>
-<p><a href="$Parent.Link" title="$Parent.Title" class="hidden-print"><i class="fa fa-angle-left mr-1" aria-hidden="true"></i><%t CWP.News.BACK "Back to the news" %></a></p>
+<p><a href="$Parent.Link" class="hidden-print"><i class="fa fa-angle-left mr-1" aria-hidden="true"></i><%t CWP.News.BACK "Back to the news" %></a></p>
 
 $Form


### PR DESCRIPTION
Reads out the News/Events holder title first which usually just "News/Events". I don't think this information is providing anymore benefit to the user.