### PR TITLE
FIX Remove redundant roles and titles from sitemap

### DIFF
--- a/templates/Includes/SitemapNode.ss
+++ b/templates/Includes/SitemapNode.ss
@@ -15,10 +15,10 @@
 <% end_if %>
 
 <div class="page-toggle__children">
-    <a href="{$Link}" class="sitemap-link" title="<%t SitemapNode_ss.GO_TO_LABEL "Go to {page} page" page=$MenuTitle %>">
+    <a href="{$Link}" class="sitemap-link">
         {$MenuTitle}
     </a>
 
     <%-- Children are populated via AJAX --%>
-    <ul id="children-{$ID}" class="collapse" role="tablist"></ul>
+    <ul id="children-{$ID}" class="collapse"></ul>
 </div>

--- a/templates/Includes/SitemapNodeChildren.ss
+++ b/templates/Includes/SitemapNodeChildren.ss
@@ -1,6 +1,6 @@
 <% loop $Children %>
     <% if $ShowInMenus %>
-        <li role="tab" data-pagetype="$ClassName" class="$FirstLast class-$ClassName">
+        <li data-pagetype="$ClassName" class="$FirstLast class-$ClassName">
             <% include SitemapNode %>
         </li>
     <% end_if %>


### PR DESCRIPTION
The list of links is wrapped in a ul with a role of tablist, and each of the list items has role="tab", but it is not a tabbed interface, so this is quite incorrect. All this incorrect ARIA should be removed. The content is is a simple list of links, and no ARIA is required.

Remove all the redundant title attributes on the links. "Go to Home page" doesn't add anything useful to a link called "Home". It only gets in the way visually, especially for screen magnification users, and aurally for screen reader or text-to-speech users. 