### PR TITLE
FIX Add accessible name to reflect the components function

### DIFF
--- a/templates/Includes/LanguageSelector.ss
+++ b/templates/Includes/LanguageSelector.ss
@@ -2,7 +2,7 @@
     <div class="btn-group float-right language-selector" id="header-language-toggle">
         <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="<%t CWPLanguageSelector.LANGUAGE_SELECTOR "Language selector" %>">
             <i class="fa fa-language" aria-hidden="true"></i>
-            <span class="d-none d-sm-inline">Language</span>
+            <span class="d-none d-sm-inline"><%t CWP_LanguageSelector "Language" %></span>
         </button>
         <div class="dropdown-menu dropdown-menu-right">
             <% loop $Locales %>

--- a/templates/Includes/LanguageSelector.ss
+++ b/templates/Includes/LanguageSelector.ss
@@ -2,19 +2,15 @@
     <div class="btn-group float-right language-selector" id="header-language-toggle">
         <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="<%t CWPLanguageSelector.LANGUAGE_SELECTOR "Language selector" %>">
             <i class="fa fa-language" aria-hidden="true"></i>
-            <span class="d-none d-sm-inline">
-                $SelectedLanguage
-            </span>
+            <span class="d-none d-sm-inline">Language</span>
         </button>
-        <ul class="dropdown-menu dropdown-menu-right">
+        <div class="dropdown-menu dropdown-menu-right">
             <% loop $Locales %>
-                <li>
-                    <a href="$Link" lang="$LocaleRFC1766" class="dropdown-item<% if $LinkingMode == 'Current' %> active<% end_if %>">
-                        <%-- Note: if you have multiple locales within the same language, you can use $Title instead --%>
-                        $LanguageNative
-                    </a>
-                </li>
+                <a href="$Link" lang="$LocaleRFC1766" class="dropdown-item<% if $LinkingMode == 'current' %> active<% end_if %>">
+                    <%-- Note: if you have multiple locales within the same language, you can use $Title instead --%>
+                    $LanguageNative
+                </a>
             <% end_loop %>
-        </ul>
+        </div>
     </div>
 <% end_if %>


### PR DESCRIPTION
Related: https://github.com/silverstripe/cwp-starter-theme/pull/137

Even at wider viewports, when the component has an accessible name, that accessible name does not clearly reflect the component's function--it only names a language. A better name visual label and accessible name would be "Language", with, in this case, English and Māori being the options to choose from. Otherwise, on an English page, what is a button called "English" supposed to do?