### PR TITLE
FIX - 2.0 - Use https for requesting jquery

### DIFF
--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -23,7 +23,7 @@
         <footer class="footer-site">
             <% include Footer %>
         </footer>
-        <% require javascript('//code.jquery.com/jquery-3.4.1.min.js') %>
+        <% require javascript('https://code.jquery.com/jquery-3.4.1.min.js') %>
         <% require themedJavascript('dist/js/main.js') %>
         <% include GoogleAnalytics %>
     </body>


### PR DESCRIPTION
This is because https://observatory.mozilla.org complains about using protocol-relative URLs via src="//..."

Resolves https://github.com/silverstripe/cwp-starter-theme/issues/172