### PR TITLE
FIX Support validation attributes in UserForms templates

### DIFF
--- a/templates/SilverStripe/UserForms/FormField/UserFormsCheckboxSetField.ss
+++ b/templates/SilverStripe/UserForms/FormField/UserFormsCheckboxSetField.ss
@@ -9,6 +9,7 @@
                 value="$Value.ATT"
                 <% if $isChecked %>checked="checked"<% end_if %>
                 <% if $isDisabled %> disabled="disabled"<% end_if %>
+                $Top.getValidationAttributesHTML().RAW
             />
             <label for="$ID" class="form-check-label">
                 $Title

--- a/templates/SilverStripe/UserForms/FormField/UserFormsOptionSetField.ss
+++ b/templates/SilverStripe/UserForms/FormField/UserFormsOptionSetField.ss
@@ -9,6 +9,7 @@
         <% if $isChecked %>checked<% end_if %>
         <% if $isDisabled %>disabled<% end_if %>
         <% if $Up.Required %>required<% end_if %>
+        $Top.getValidationAttributesHTML().RAW
     />
     <label for="$ID" class="form-check-label">
         $Title


### PR DESCRIPTION
When running a (future) patched release of UserForms, validation attributes on CheckBoxSetFields and OptionSetFields will be rendered correctly.

See https://github.com/silverstripe/silverstripe-userforms/pull/988