### PR TITLE
FIX Adjust ElementalArea check to allow nesting of regular Pages

### DIFF
--- a/templates/Layout/Page.ss
+++ b/templates/Layout/Page.ss
@@ -9,7 +9,7 @@
     </div>
     <div class="row">
         <section class="col-lg-8<% if not $Children %> offset-lg-2<% end_if %>">
-            <% if $ElementalArea %>
+            <% if $ElementalAreaID %>
                 <%-- Support for content blocks, if enabled --%>
                 <% if $ElementalArea.RichLinks %>
                     $ElementalArea.RichLinks %>


### PR DESCRIPTION
When nesting a regular `Page` underneath a `BlockPage`, this theme currently breaks, looking for an `ElementalArea` method on the controller. By shifting to a check against `ElementalAreaID`, the Page can render successfully.