### PR TITLE
Fix Missing `Required` helper text for Checkbox

### DIFF
--- a/templates/SilverStripe/UserForms/Model/EditableFormField/EditableCheckbox_holder.ss
+++ b/templates/SilverStripe/UserForms/Model/EditableFormField/EditableCheckbox_holder.ss
@@ -3,6 +3,9 @@
         {$Field}
         <label class="form-check-label" for="{$ID}">
             {$Title}
+            <% if $Required %>
+                <span class="required help-text">(<%t CWP_Form.RequiredLabel "required" %>)</span>
+            <% end_if %>
         </label>
         <% include FormFieldMessage %>
         <% include FormFieldDescription %>


### PR DESCRIPTION
I am not really sure if this is needed as this Checkbox does not have a Field Title/Label on Top to add the `required` helper text. Maybe it should be treated differently but sending in the PR just in case.

### FROM
![image](https://user-images.githubusercontent.com/11882563/93463668-2f96fe00-f93c-11ea-8a0f-7b0aa25e9f9b.png)

### TO
![image](https://user-images.githubusercontent.com/11882563/93463631-2017b500-f93c-11ea-8eba-db806bd74fbe.png)
