### PR TITLE
Fixing the missing Filter to show Span only when field is required

### DIFF
--- a/templates/SilverStripe/UserForms/Model/EditableFormField/EditableMultipleOptionField_holder.ss
+++ b/templates/SilverStripe/UserForms/Model/EditableFormField/EditableMultipleOptionField_holder.ss
@@ -3,7 +3,9 @@
     <% if $Title %>
         <legend class="left">
             $Title
-            <span class="required help-text" aria-required="true">(required)</span>
+            <% if $Required %>
+                <span class="help-text" aria-required="true">(required)</span>
+            <% end_if %>
         </legend>
     <% end_if %>
     {$Field}

--- a/templates/SilverStripe/UserForms/Model/EditableFormField/EditableMultipleOptionField_holder.ss
+++ b/templates/SilverStripe/UserForms/Model/EditableFormField/EditableMultipleOptionField_holder.ss
@@ -4,7 +4,7 @@
         <legend class="left">
             $Title
             <% if $Required %>
-                <span class="help-text" aria-required="true">(required)</span>
+                <span class="required help-text" aria-required="true">(required)</span>
             <% end_if %>
         </legend>
     <% end_if %>


### PR DESCRIPTION
Missed out the `If ` Condition to only show span whenever the field group is required.