### PR TITLE
FIX Remove reference to empty css file.

### DIFF
--- a/templates/CommentsInterface.ss
+++ b/templates/CommentsInterface.ss
@@ -1,5 +1,3 @@
-<% require themedCSS('comments', 'comments') %>
-
 <% if $CommentsEnabled %>
     <div id="$CommentHolderID" class="comments-holder-container">
         <h2 class="h3 comments-heading"><%t CommentsInterface_ss.POSTCOM 'Post your comment' %></h2>


### PR DESCRIPTION
This file is removed in the latest version of the comments module. See https://github.com/silverstripe/silverstripe-comments/pull/358

Resolves this error during dev/build:
> ERROR [Emergency]: Uncaught InvalidArgumentException: The css file doesn't exist. Please check if the file comments.css exists in any context or search for themedCSS references calling this file in your templates.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/644